### PR TITLE
safety-module-bpt-power

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -262,6 +262,7 @@ import * as gysrStakingBalance from './gysr-staking-balance';
 import * as starsharks from './starsharks';
 import * as printerFinancial from './printer-financial';
 import * as ethercatsFoundersSeries from './ethercats-founders-series';
+import * as safetyModuleBptPower from './safety-module-bpt-power';
 
 const strategies = {
   'landdao-token-tiers': landDaoTiers,
@@ -524,7 +525,8 @@ const strategies = {
   'gysr-staking-balance': gysrStakingBalance,
   starsharks,
   'printer-financial': printerFinancial,
-  'ethercats-founders-series': ethercatsFoundersSeries
+  'ethercats-founders-series': ethercatsFoundersSeries,
+  'safety-module-bpt-power': safetyModuleBptPower
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/safety-module-bpt-power/README.md
+++ b/src/strategies/safety-module-bpt-power/README.md
@@ -1,0 +1,18 @@
+# staked-psp-balance
+
+This strategy compute the voting power of a staker relative to one token involved in a Aave like safety module that accepts arbitrary balancer LP token as staked token.
+It uses balancer-pool-id strategy.
+
+To simplify async flow, it requires to pass couple of parameters: 
+- balancer pool id
+- safety module (address, decimals)
+- voting token (address, decimals)
+
+
+This strategy works under 2 different regimes:
+
+1/ if voting_token matches reward_token of safety module 
+-> count for staked tokens and unclaimed rewards
+
+2/ else 
+-> count for staked tokens only

--- a/src/strategies/safety-module-bpt-power/README.md
+++ b/src/strategies/safety-module-bpt-power/README.md
@@ -1,6 +1,6 @@
 # staked-psp-balance
 
-This strategy compute the voting power of a staker relative to one token involved in a Aave like safety module that accepts arbitrary balancer LP token as staked token.
+This strategy computes the voting power of a staker relative to one token involved in a Aave like safety module that accepts arbitrary balancer LP token as staked token.
 It uses balancer-pool-id strategy.
 
 To simplify async flow, it requires to pass couple of parameters: 

--- a/src/strategies/safety-module-bpt-power/examples.json
+++ b/src/strategies/safety-module-bpt-power/examples.json
@@ -4,7 +4,7 @@
     "strategy": {
       "name": "safety-module-bpt-power",
       "params": {
-        "symbol": "stkPSPBpt",
+        "symbol": "PSP",
         "balancerPoolId": "0xcb0e14e96f2cefa8550ad8e4aea344f211e5061d00020000000000000000011a",
         "safetyModule": {
           "address": "0xC8DC2Ec5f5e02bE8b37A8444a1931F02374A17ab",

--- a/src/strategies/safety-module-bpt-power/examples.json
+++ b/src/strategies/safety-module-bpt-power/examples.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "Example safety module bpt query",
+    "strategy": {
+      "name": "safety-module-bpt-power",
+      "params": {
+        "symbol": "stkPSPBpt",
+        "balancerPoolId": "0xcb0e14e96f2cefa8550ad8e4aea344f211e5061d00020000000000000000011a",
+        "safetyModule": {
+          "address": "0xC8DC2Ec5f5e02bE8b37A8444a1931F02374A17ab",
+          "decimals": 18
+        },
+        "votingToken": {
+          "address": "0xcAfE001067cDEF266AfB7Eb5A286dCFD277f3dE5",
+          "decimals": 18
+        }
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x0ddc793680ff4f5793849c8c6992be1695cbe72a",
+      "0x9c0d72f2ac26420cb7eeb155bf401b672840e87b",
+      "0x7494eb2916cad8649f4f91eb1db6e20be605dad6",
+      "0xb7b65acf585c29070b9926c089fcfa1eb9983d3d",
+      "0x9824697f7c12cabada9b57842060931c48dea969",
+      "0x5b52e503c9e1440b47991bc0a64599c1c916084c",
+      "0x3ce06981bc523f950e3df346878216365b24b6fe",
+      "0xf2078c58d6c38c893af4e40d7b09843ec3b7d26c",
+      "0xcff61382e659603046358f86a119efd127d5bb48",
+      "0x8f60501dE5b9b01F9EAf1214dbE1924aA97F7fd0",
+      "0x9B8e8dD9151260c21CB6D7cc59067cd8DF306D58",
+      "0x17ea92D6FfbAA1c7F6B117c1E9D0c88ABdc8b84C",
+      "0x38C0039247A31F3939baE65e953612125cB88268"
+    ],
+    "snapshot": 14215928
+  }
+]

--- a/src/strategies/safety-module-bpt-power/index.ts
+++ b/src/strategies/safety-module-bpt-power/index.ts
@@ -169,18 +169,19 @@ export async function strategy(
     safetyModuleRewardsToken.toLowerCase() ===
     options.votingToken.address.toLowerCase();
 
+  const safetyModuleTotalSupply = parseFloat(
+    formatUnits(
+      safetyModuleGlobalState[TOTAL_SUPPLY_ATTR],
+      options.safetyModule.decimals
+    )
+  );
+
   const scores = Object.fromEntries(
     Object.entries(accountsStakesAndRewards).map(
       ([address, accountStakesAndRewards]) => {
         const accountSafetyModuleBalance = parseFloat(
           formatUnits(
             accountStakesAndRewards[BALANCE_OF_ATTR],
-            options.safetyModule.decimals
-          )
-        );
-        const safetyModuleTotalSupply = parseFloat(
-          formatUnits(
-            safetyModuleGlobalState[TOTAL_SUPPLY_ATTR],
             options.safetyModule.decimals
           )
         );

--- a/src/strategies/safety-module-bpt-power/index.ts
+++ b/src/strategies/safety-module-bpt-power/index.ts
@@ -1,0 +1,213 @@
+import { strategy as balancerPoolIdStrategy } from '../balancer-poolid';
+import { BigNumberish } from '@ethersproject/bignumber';
+import { Multicaller } from '../../utils';
+import { formatUnits } from '@ethersproject/units';
+
+export const author = 'paraswap';
+export const version = '0.1.0';
+
+interface Options {
+  balancerPoolId: string;
+  safetyModule: {
+    address: string;
+    decimals: number;
+  };
+  votingToken: {
+    address: string;
+    decimals: number;
+  };
+}
+
+type FetchSafetyModuleScoreOutput = Promise<number>;
+
+async function fetchSafetyModuleScore(
+  space,
+  network,
+  provider,
+  addresses,
+  options: Options,
+  snapshot
+): FetchSafetyModuleScoreOutput {
+  const scores = await balancerPoolIdStrategy(
+    space,
+    network,
+    provider,
+    [options.safetyModule.address],
+    {
+      poolId: options.balancerPoolId,
+      token: options.votingToken.address
+    },
+    snapshot
+  );
+
+  return parseFloat(scores[options.safetyModule.address]);
+}
+
+const SafetyModuleMinABI = [
+  'function totalSupply() external view returns (uint256)',
+  'function REWARD_TOKEN() external view returns (address)',
+  'function decimals() view returns (uint8)',
+  'function balanceOf(address account) external view returns (uint256)',
+  'function getTotalRewardsBalance(address staker) view returns (uint256)'
+];
+
+const TOTAL_SUPPLY_ATTR = 'totalSupply';
+const REWARD_TOKEN_ATTR = 'rewardToken';
+const BALANCE_OF_ATTR = 'balanceOf';
+const REWARDS_OF_ATTR = 'totalRewardsBalance';
+
+type FetchAccountsSafetyModuleStakesAndRewardsOuput = Promise<{
+  [address: string]: {
+    [BALANCE_OF_ATTR]: BigNumberish;
+    [REWARD_TOKEN_ATTR]: BigNumberish;
+  };
+}>;
+
+async function fetchAccountsSafetyModuleStakesAndRewards(
+  space,
+  network,
+  provider,
+  addresses,
+  options: Options,
+  snapshot
+): FetchAccountsSafetyModuleStakesAndRewardsOuput {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, SafetyModuleMinABI, {
+    blockTag
+  });
+
+  addresses.forEach((address) => {
+    multi.call(
+      `${BALANCE_OF_ATTR}_${address}`,
+      options.safetyModule.address,
+      'balanceOf',
+      [address]
+    );
+    multi.call(
+      `${REWARDS_OF_ATTR}_${address}`,
+      options.safetyModule.address,
+      'getTotalRewardsBalance',
+      [address]
+    );
+  });
+
+  const result: Record<string, BigNumberish> = await multi.execute();
+
+  return Object.entries(result).reduce((acc, [key, value]) => {
+    const [attr, addr] = key.split('_');
+
+    if (!acc[addr]) {
+      acc[addr] = {};
+    }
+
+    acc[addr][attr] = value;
+
+    return acc;
+  }, {});
+}
+
+type FetchSafetyModuleGlobalStateOutput = Promise<{
+  [TOTAL_SUPPLY_ATTR]: BigNumberish;
+  [REWARD_TOKEN_ATTR]: string;
+}>;
+
+async function fetchSafetyModuleGlobalState(
+  space,
+  network,
+  provider,
+  addresses,
+  options: Options,
+  snapshot
+): FetchSafetyModuleGlobalStateOutput {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, SafetyModuleMinABI, {
+    blockTag
+  });
+
+  multi.call(REWARD_TOKEN_ATTR, options.safetyModule.address, 'REWARD_TOKEN');
+  multi.call(TOTAL_SUPPLY_ATTR, options.safetyModule.address, 'totalSupply');
+
+  const result: {
+    [REWARD_TOKEN_ATTR]: string;
+    [TOTAL_SUPPLY_ATTR]: BigNumberish;
+  } = await multi.execute();
+
+  return result;
+}
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options: Options,
+  snapshot
+) {
+  const [
+    safetyModuleScore,
+    accountsStakesAndRewards,
+    safetyModuleGlobalState
+  ] = await Promise.all(
+    [
+      fetchSafetyModuleScore,
+      fetchAccountsSafetyModuleStakesAndRewards,
+      fetchSafetyModuleGlobalState
+    ].map((fn) =>
+      fn(space, network, provider, addresses, options, snapshot)
+    ) as [
+      FetchSafetyModuleScoreOutput,
+      FetchAccountsSafetyModuleStakesAndRewardsOuput,
+      FetchSafetyModuleGlobalStateOutput
+    ]
+  );
+
+  const safetyModuleRewardsToken = safetyModuleGlobalState[REWARD_TOKEN_ATTR];
+
+  const votingAndRewardTokenMatching =
+    safetyModuleRewardsToken.toLowerCase() ===
+    options.votingToken.address.toLowerCase();
+
+  const scores = Object.fromEntries(
+    Object.entries(accountsStakesAndRewards).map(
+      ([address, accountStakesAndRewards]) => {
+        const accountSafetyModuleBalance = parseFloat(
+          formatUnits(
+            accountStakesAndRewards[BALANCE_OF_ATTR],
+            options.safetyModule.decimals
+          )
+        );
+        const safetyModuleTotalSupply = parseFloat(
+          formatUnits(
+            safetyModuleGlobalState[TOTAL_SUPPLY_ATTR],
+            options.safetyModule.decimals
+          )
+        );
+
+        const accountSharePercent =
+          accountSafetyModuleBalance / safetyModuleTotalSupply;
+
+        const accountStakedScore = accountSharePercent * safetyModuleScore;
+
+        if (!votingAndRewardTokenMatching) {
+          return [address, accountStakedScore];
+        }
+
+        const accountRewardsScore = parseFloat(
+          formatUnits(
+            accountStakesAndRewards[REWARDS_OF_ATTR],
+            options.votingToken.decimals
+          )
+        );
+
+        const accountStakedAndRewardsScore =
+          accountStakedScore + accountRewardsScore;
+
+        return [address, accountStakedAndRewardsScore];
+      }
+    )
+  );
+
+  return scores;
+}

--- a/src/strategies/safety-module-bpt-power/index.ts
+++ b/src/strategies/safety-module-bpt-power/index.ts
@@ -3,7 +3,7 @@ import { BigNumberish } from '@ethersproject/bignumber';
 import { Multicaller } from '../../utils';
 import { formatUnits } from '@ethersproject/units';
 
-export const author = 'paraswap';
+export const author = 'mwamedacen';
 export const version = '0.1.0';
 
 interface Options {

--- a/src/strategies/safety-module-bpt-power/index.ts
+++ b/src/strategies/safety-module-bpt-power/index.ts
@@ -112,15 +112,16 @@ async function fetchAccountsSafetyModuleStakesAndRewards(
 type FetchSafetyModuleGlobalStateOutput = Promise<{
   [TOTAL_SUPPLY_ATTR]: BigNumberish;
   [REWARD_TOKEN_ATTR]: string;
+  [STAKED_TOKEN_ATTR]: string;
 }>;
 
 async function fetchSafetyModuleGlobalState(
-  space,
-  network,
+  space: string,
+  network: string,
   provider,
-  addresses,
+  addresses: string[],
   options: Options,
-  snapshot
+  snapshot: number
 ): FetchSafetyModuleGlobalStateOutput {
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
 

--- a/src/strategies/safety-module-bpt-power/index.ts
+++ b/src/strategies/safety-module-bpt-power/index.ts
@@ -21,12 +21,12 @@ interface Options {
 type FetchSafetyModuleScoreOutput = Promise<number>;
 
 async function fetchSafetyModuleScore(
-  space,
-  network,
+  space: string,
+  network: string,
   provider,
-  addresses,
+  addresses: string[],
   options: Options,
-  snapshot
+  snapshot: number
 ): FetchSafetyModuleScoreOutput {
   const scores = await balancerPoolIdStrategy(
     space,
@@ -66,12 +66,12 @@ type FetchAccountsSafetyModuleStakesAndRewardsOuput = Promise<{
 }>;
 
 async function fetchAccountsSafetyModuleStakesAndRewards(
-  space,
-  network,
+  space: string,
+  network: string,
   provider,
-  addresses,
+  addresses: string[],
   options: Options,
-  snapshot
+  snapshot: number
 ): FetchAccountsSafetyModuleStakesAndRewardsOuput {
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
 
@@ -142,12 +142,12 @@ async function fetchSafetyModuleGlobalState(
 }
 
 export async function strategy(
-  space,
-  network,
+  space: string,
+  network: string,
   provider,
-  addresses,
+  addresses: string[],
   options: Options,
-  snapshot
+  snapshot: number
 ) {
   const [
     safetyModuleScore,

--- a/src/strategies/safety-module-bpt-power/schema.json
+++ b/src/strategies/safety-module-bpt-power/schema.json
@@ -1,0 +1,63 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$ref": "#/definitions/Strategy",
+	"definitions": {
+		"Strategy": {
+			"title": "Strategy",
+			"type": "object",
+			"properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. PSP"]
+        },
+				"balancerPoolId": {
+					"type": "string",
+					"title": "BalancerPoolId",
+					"examples": ["e.g. 0xcb0e14e96f2cefa8550ad8e4aea344f211e5061d00020000000000000000011a"],
+          "pattern": "^0x[a-fA-F0-9]{64}$",
+					"minLength": 66,
+					"maxLength": 66
+				},
+				"safetyModule": {
+					"type": "object",
+					"title": "SafetyModule",
+					"properties": {
+						"address": {
+							"type": "string",
+							"title": "Address",
+							"pattern": "^0x[a-fA-F0-9]{40}$",
+							"minLength": 42,
+							"maxLength": 42
+						},
+						"decimals": {
+							"type": "number",
+							"title": "Decimals",
+							"examples": ["e.g. 18"]
+						}
+					}
+				},
+				"votingToken": {
+					"type": "object",
+					"title": "VotingToken",
+					"properties": {
+						"address": {
+							"type": "string",
+							"title": "Address",
+							"pattern": "^0x[a-fA-F0-9]{40}$",
+							"minLength": 42,
+							"maxLength": 42
+						},
+						"decimals": {
+							"type": "number",
+							"title": "Decimals",
+							"examples": ["e.g. 18"]
+						}
+					}
+				}
+			},
+			"required": ["symbol", "balancerPoolId", "safetyModule", "votingToken"],
+			"additionalProperties": false
+		}
+	}
+}


### PR DESCRIPTION
Testing steps:

1/ pick the last ethereum block number and set it example
2/ pick one of the addresses and enter it on Debank or Zerion  and navigate to ParaSwap / Farming section
3/  run : `nvm use 15 && npm run test --strategy=safety-module-bpt-power`
4/ compare debank and script output

The result between debank/zerion and script output might show a little difference due to:
- can hardly make sure zerion/debank and snapshot script executed at same block number
- snapshot script rely on balancer snapshot which relies on balancersubgraph whereas Debank/Zerion is blackbox

Alternatively, more exact but more cumbersome:
5/ check at stkPSPBpt contract and balancer pool on etherscan
- record total unclaimed rewards by looking at `getTotalRewardsBalance()`
- fetch total balance of stkPSPBpt and try to come up with PSP-ETH breakdown by checking at pool balance